### PR TITLE
Fix package import in README

### DIFF
--- a/better_readme.md
+++ b/better_readme.md
@@ -29,23 +29,23 @@ import embyclient
 Configure a client instance:
 
 ```python
-import embyclient
-from embyclient.rest import ApiException
+import emby_client
+from emby_client.rest import ApiException
 
 # Configure API key authorization: apikeyauth
-configuration = embyclient.Configuration()
+configuration = emby_client.Configuration()
 configuration.api_key['api_key'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['api_key'] = 'Bearer'
 
 # create an instance of the API class
-client = embyclient.ApiClient(configuration)
+client = emby_client.ApiClient(configuration)
 ```
 
 Then use the client to interact via specific API services:
 
 ```python
-activity_log_service = embyclient.ActivityLogServiceApi(client)
+activity_log_service = emby_client.ActivityLogServiceApi(client)
 
 try:
     # Gets activity log entries


### PR DESCRIPTION
Hey there thanks a bunch for making this and publishing this to pip.

I was able to install this with `pip install embyclient` but ran into issues when importing the package with `import embyclient` like it says in your improved README. I could only get it to work when I did `import emby_client` instead. I'm not a python expert so please feel free to close the PR if it was user error! 


```
python
Python 3.10.14 (main, Aug 18 2024, 16:56:48) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import embyclient
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'embyclient'
>>> import emby_client
>>> configuration = emby_client.Configuration()
>>> type(configuration)
<class 'emby_client.configuration.Configuration'>
>>>
```

`pip uninstall embyclient` shows the package at `emby_client`
```
Found existing installation: embyclient 4.9.0.33
Uninstalling embyclient-4.9.0.33:
  Would remove:
    /Users/khalpin11/.pyenv/versions/3.10.14/lib/python3.10/site-packages/emby_client/*
    /Users/khalpin11/.pyenv/versions/3.10.14/lib/python3.10/site-packages/embyclient-4.9.0.33.dist-info/*
Proceed (Y/n)?
```